### PR TITLE
优化CI/CD流程：解决Cloudflare Pages自动部署时机问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ name: CI Pipeline # 工作流名称
 # 触发条件：推送或拉取请求时执行
 on:
   push: # 推送代码时触发
-    branches: [master] # 仅在main和develop分支触发
+    branches: [master, develop] # 在master和develop分支触发
+  pull_request: # 拉取请求时触发
+    branches: [master] # 针对master分支的PR
 
 # 设置并发控制，确保同一分支只有一个工作流运行
 concurrency:
@@ -101,20 +103,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [lint, test, e2e] # 依赖所有测试任务完成
-    if: github.ref == 'refs/heads/master' # 只在主分支部署
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' # 只在master分支直接推送时部署
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -125,7 +127,14 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Deploy ready signal
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=fl-ai-interface
+
+      - name: Deployment success notification
         run: |
-          echo "✅ All tests passed! Ready for deployment."
-          echo "Build artifacts are ready for Cloudflare Pages."
+          echo "🚀 Deployment completed successfully!"
+          echo "✅ All tests passed and application deployed to Cloudflare Pages."

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,78 +1,180 @@
-# Cloudflare Pages 部署配置
+# Cloudflare Pages 部署指南
 
-## 问题描述
+## 概述
 
-当使用 Cloudflare Pages 连接 GitHub 仓库时，每次 push 都会触发自动部署，但此时 GitHub Actions CI 流程可能还在运行中。这会导致：
+本项目使用 GitHub Actions CI/CD 流程与 Cloudflare Pages 集成，确保只有通过完整测试验证的代码才会被部署到生产环境。
 
-1. 部署可能基于未经测试验证的代码
-2. CI 测试失败时，错误的代码已经被部署
-3. 资源浪费（同时运行 CI 和部署）
+## 部署流程
 
-## 解决方案
+### 1. CI/CD 工作流程
 
-### 方案一：GitHub Actions 控制部署（推荐）
+#### 触发条件
 
-我们在 `.github/workflows/ci.yml` 中添加了 `deploy` 任务：
+- **develop 分支推送**: 运行完整的 CI 测试（lint、单元测试、E2E测试）
+- **master 分支推送**: 运行 CI 测试 + 自动部署到 Cloudflare Pages
+- **Pull Request 到 master**: 运行 CI 测试验证代码质量
 
-- **依赖关系**：只有在 `lint`、`test`、`e2e` 三个任务都成功后才执行
-- **分支限制**：只在 `main` 和 `develop` 分支执行部署
-- **并发控制**：确保同一分支只有一个工作流运行
+#### 部署时机控制
 
-### 方案二：Cloudflare Pages 配置
+- ✅ **正确流程**: develop → PR to master → CI 通过 → 合并到 master → 自动部署
+- ❌ **避免问题**: Cloudflare Pages 不会在 PR 创建时自动部署，只在 master 分支推送且 CI 通过后部署
 
-在 Cloudflare Pages 设置中：
+### 2. Cloudflare Pages 配置
 
-1. **构建配置**：
-   - 构建命令：`pnpm install && pnpm run build`
-   - 构建输出目录：`dist`
-   - Root directory：`/`
+#### 必需配置步骤
 
-2. **部署分支**：
-   - 生产分支：`main`
-   - 预览分支：`develop`
+1. **禁用 Cloudflare Pages 自动部署**
+   - 登录 Cloudflare Dashboard
+   - 进入 Pages 项目设置
+   - 在 "Builds & deployments" 中禁用 "Automatic deployments"
+   - 这样可以防止 Cloudflare 在代码推送时立即部署，而是等待 GitHub Actions 完成测试
 
-3. **环境变量**：
+2. **GitHub Secrets 配置**
+   需要在 GitHub 仓库设置中添加以下 Secrets：
+
    ```
-   NODE_VERSION=18
-   NPM_FLAGS=--version
+   CLOUDFLARE_API_TOKEN=your_cloudflare_api_token
+   CLOUDFLARE_ACCOUNT_ID=your_cloudflare_account_id
    ```
 
-### 方案三：使用 GitHub Status Checks（高级）
+3. **获取 Cloudflare API Token**
+   - 访问 [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens)
+   - 创建自定义 Token，权限包括：
+     - Zone:Zone:Read
+     - Zone:Page Rules:Edit
+     - Account:Cloudflare Pages:Edit
 
-在 Cloudflare Pages 中启用 "Wait for CI" 选项，这样 Cloudflare 会等待 GitHub Actions 完成后再开始部署。
+### 3. 项目配置文件
 
-## 推荐配置
+#### wrangler.jsonc
 
-### Cloudflare Pages 设置
-
-```yaml
-# 在 Cloudflare Pages 项目设置中
-Build command: pnpm install && pnpm run build
-Build output directory: dist
-Root directory: /
-Node.js version: 18
+```json
+{
+  "name": "fl-ai-interface",
+  "compatibility_date": "2025-09-23",
+  "build": {
+    "command": "pnpm run build"
+  },
+  "assets": {
+    "directory": "./dist"
+  }
+}
 ```
 
-### 部署流程
+#### package.json 构建脚本
 
-1. 开发者 push 代码到 GitHub
-2. GitHub Actions 自动运行 CI 流程：
-   - ESLint 代码检查
-   - Jest 单元测试
-   - Cypress E2E 测试
-3. 所有测试通过后，执行 `deploy` 任务
-4. Cloudflare Pages 检测到成功的部署信号后开始构建
-5. 部署完成
+```json
+{
+  "scripts": {
+    "build": "webpack --mode production"
+  }
+}
+```
 
-## 文件说明
+### 4. 部署命令
 
-- `_headers`：Cloudflare Pages 安全头配置
-- `.github/workflows/ci.yml`：完整的 CI/CD 流程
-- `package.json`：包含 `build` 脚本
+GitHub Actions 使用以下命令进行部署：
 
-## 注意事项
+```bash
+wrangler pages deploy dist --project-name=fl-ai-interface
+```
 
-1. 确保 Cloudflare Pages 项目连接的是正确的 GitHub 仓库和分支
-2. 在 Cloudflare Pages 设置中禁用自动部署，改为手动触发或基于 webhook
-3. 监控部署日志，确保构建过程正常
-4. 考虑设置部署通知，及时了解部署状态
+## 推荐的开发工作流
+
+### 功能开发流程
+
+1. 在 `develop` 分支开发新功能
+2. 推送到 `develop` 分支触发 CI 测试
+3. 创建 PR 从 `develop` 到 `master`
+4. PR 会触发 CI 测试验证
+5. 测试通过后合并 PR 到 `master`
+6. `master` 分支推送触发 CI 测试 + 自动部署
+
+### 紧急修复流程
+
+1. 直接在 `master` 分支创建 hotfix
+2. 推送触发 CI 测试 + 自动部署
+3. 将修复同步回 `develop` 分支
+
+## 环境变量
+
+### 构建时环境变量
+
+- `NODE_ENV=production`: 生产环境构建优化
+- `CI=true`: CI 环境标识
+
+### 运行时环境变量
+
+可以在 Cloudflare Pages 项目设置中配置：
+
+- 生产环境变量
+- 预览环境变量
+
+## 监控和日志
+
+### GitHub Actions 日志
+
+- 查看 CI/CD 流程执行状态
+- 构建和测试结果
+- 部署状态和错误信息
+
+### Cloudflare Pages 日志
+
+- 部署历史记录
+- 构建日志和错误信息
+- 性能监控数据
+
+## 故障排除
+
+### 常见问题
+
+1. **部署失败：dist 目录不存在**
+   - 确保 `wrangler.jsonc` 中配置了正确的构建命令
+   - 检查 webpack 配置输出路径
+
+2. **API Token 权限不足**
+   - 验证 Cloudflare API Token 权限
+   - 确保 Account ID 正确
+
+3. **CI 测试失败导致部署跳过**
+   - 检查 lint、单元测试、E2E 测试结果
+   - 修复测试问题后重新推送
+
+### 调试命令
+
+本地测试部署：
+
+```bash
+# 安装依赖
+pnpm install
+
+# 构建项目
+pnpm run build
+
+# 本地预览
+npx wrangler pages dev dist
+
+# 手动部署（需要配置 wrangler auth）
+npx wrangler pages deploy dist --project-name=fl-ai-interface
+```
+
+## 性能优化
+
+### 构建优化
+
+- Webpack 代码分割和压缩
+- CSS 提取和压缩
+- 图片和字体资源优化
+
+### 部署优化
+
+- 启用 Cloudflare CDN 缓存
+- 配置适当的缓存策略
+- 使用 HTTP/2 和 Brotli 压缩
+
+## 安全考虑
+
+- API Token 存储在 GitHub Secrets 中
+- 生产环境变量与开发环境隔离
+- 定期轮换 API Token
+- 监控部署日志中的敏感信息泄露


### PR DESCRIPTION
- 修改CI触发条件，支持develop分支和PR验证
- 添加手动控制的Cloudflare Pages部署步骤
- 确保只有CI测试通过后才触发部署
- 更新DEPLOYMENT.md文档，详细说明新的部署流程
- 配置GitHub Actions使用wrangler-action进行部署