### PR TITLE
修复CI重复触发问题：优化GitHub Actions触发条件

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ name: CI Pipeline # 工作流名称
 # 触发条件：推送或拉取请求时执行
 on:
   push: # 推送代码时触发
-    branches: [master, develop] # 在master和develop分支触发
+    branches: [develop] # 只在develop分支触发
   pull_request: # 拉取请求时触发
     branches: [master] # 针对master分支的PR
+  workflow_dispatch: # 手动触发
 
 # 设置并发控制，确保同一分支只有一个工作流运行
 concurrency:
@@ -103,7 +104,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [lint, test, e2e] # 依赖所有测试任务完成
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push' # 只在master分支直接推送时部署
+    if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/master' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) # 手动触发或PR合并到master时部署
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- 移除master分支的push触发，避免PR合并时重复运行CI
- 保留develop分支的push触发用于开发测试
- 保留master分支的pull_request触发用于PR验证
- 添加workflow_dispatch支持手动触发
- 修改部署条件：支持手动触发或PR合并到master时部署