### PR TITLE
修复部署条件：简化PR合并到master时的部署触发逻辑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [lint, test, e2e] # 依赖所有测试任务完成
-    if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/master' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) # 手动触发或PR合并到master时部署
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master') # 手动触发或PR合并到master时部署
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- 移除不必要的github.ref检查
- 使用github.event.pull_request.base.ref检查目标分支
- 确保PR合并到master分支时能正确触发部署